### PR TITLE
ENH: update firebase lib based on current v '^9.2.0'

### DIFF
--- a/src/lib/firebase.prod.js
+++ b/src/lib/firebase.prod.js
@@ -1,6 +1,6 @@
-import Firebase from 'firebase/app';
-import 'firebase/firestore';
-import 'firebase/auth';
+import Firebase from 'firebase/compat/app';
+import 'firebase/compat/firestore';
+import 'firebase/compat/auth';
 
 // 1) when seeding the database you'll have to uncomment this!
 // import { seedDatabase } from '../seed';


### PR DESCRIPTION
##Bug description 
firebase lib new version not able to import lib properly 

##Root cause
wont work if use import Firebase from 'firebase/app' & import 'firebase/firestore' & import 'firebase/auth';

##Solution description
currently i'm using "firebase": "^9.2.0" after lots of research i found import Firebase from "firebase/compat/app" & import "firebase/compat/auth" & import "firebase/compat/firestore"; this solution it's working same as you mentioned in your tutorial .